### PR TITLE
Add schedule overlap validation, upgrade to Java 25, and update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PAT_TOKEN }}
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
 
       - name: Cache Maven dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:25-jdk-alpine
 
 ENV TZ=Europe/Berlin
-RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone \
-    && apt-get update && apt-get install -y ffmpeg curl \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ffmpeg curl tzdata \
+    && cp /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && echo ${TZ} > /etc/timezone
 
 WORKDIR /app
 
@@ -12,4 +12,4 @@ COPY target/*.jar app.jar
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD curl --fail http://localhost:8084/actuator/health || exit 1
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "--enable-native-access=ALL-UNNAMED", "-jar", "app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -13,16 +13,16 @@
     <name>recorder</name>
     <description>Spring Boot based recording scheduler, that uses ffmpeg to create videos from scheduled recordings</description>
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
         <spring-boot.version>3.5.5</spring-boot.version>
         <jaffree.version>2024.08.29</jaffree.version>
-        <sqlite-jdbc.version>3.50.3.0</sqlite-jdbc.version>
+        <sqlite-jdbc.version>3.51.1.0</sqlite-jdbc.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
-        <mockito.version>5.19.0</mockito.version>
+        <mockito.version>5.21.0</mockito.version>
         <assertj.version>3.27.4</assertj.version>
     </properties>
     <dependencies>
@@ -138,8 +138,8 @@
                         <compilerArg>-Amapstruct.defaultComponentModel=spring</compilerArg>
                         <compilerArg>-Amapstruct.unmappedTargetPolicy=IGNORE</compilerArg>
                     </compilerArgs>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>25</source>
+                    <target>25</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -152,6 +152,7 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <mainClass>me.schickel.recorder.RecorderApplication</mainClass>
+                    <jvmArguments>--enable-native-access=ALL-UNNAMED</jvmArguments>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
## Changes

### Schedule Overlap Prevention
- Added validation to prevent overlapping recording schedules
- Implemented half-open interval logic `[start, end)` to allow adjacent schedules
- Added `excludeId` parameter to allow schedule updates without self-conflict
- Returns descriptive error message showing conflicting schedule filename
- Added comprehensive test coverage for overlap scenarios

### Java 25 Upgrade
- Upgraded from Java 21 to Java 25
- Updated `pom.xml` compiler source/target to Java 25
- Updated Dockerfile base image to `eclipse-temurin:25-jdk-alpine`
- Updated GitHub Actions workflow to use JDK 25
- Added `--enable-native-access=ALL-UNNAMED` JVM flag to suppress native access warnings from SQLite JDBC

### Docker Improvements
- Switched from `openjdk` to `eclipse-temurin` base image
- Migrated from Debian to Alpine Linux for smaller image size
- Updated package manager commands for Alpine compatibility

### Dependency Updates
- `sqlite-jdbc`: 3.50.3.0 → 3.51.1.0
- `mockito-core`: 5.19.0 → 5.21.0
- `lombok`: Auto-updated to 1.18.42 via Spring Boot parent

### Test Improvements
- Fixed mock stubbing issues in `ScheduleManagementServiceTest`
- Added tests for schedule overlap validation
- All 93 tests passing

## Testing
- ✅ All 93 tests passing
- ✅ Schedule overlap validation working correctly
- ✅ Application runs successfully with Java 25
- ✅ Docker build compatible with Alpine Linux
